### PR TITLE
1.x operations followup fixes

### DIFF
--- a/farm_rothamsted.farm_quick.cultivation.inc
+++ b/farm_rothamsted.farm_quick.cultivation.inc
@@ -79,7 +79,6 @@ function farm_rothamsted_cultivation_quick_form($form, &$form_state) {
     '#input_group' => TRUE,
     '#field_suffix' => t('centimeters'),
     '#element_validate' => array('element_validate_number'),
-    '#required' => TRUE,
     '#weight' => 11,
   );
 
@@ -142,25 +141,35 @@ function farm_rothamsted_cultivation_quick_form_submit($form, &$form_state) {
   // Initialize an empty measurements array.
   $measurements = array();
 
-  // Add the cultivation depth.
-  $cultivation_depth = array(
-    'measure' => 'length',
-    'value' => $form_values['depth'],
-    'units' => 'cm',
-  );
-  $measurements[] = $cultivation_depth;
-
   // Load the selected operation task.
   $operation_task = $form_values['operation_task'];
 
-  // Set log name.
-  $args = array(
-    '@qty' => $cultivation_depth['value'],
-    '@units' => $cultivation_depth['units'],
-    '@type' => $operation_task,
-    '@area' => entity_label('taxonomy_term', $area),
-  );
-  $log_name = t('Operation: @type @qty @units in @area', $args);
+  // Add the cultivation depth if provided.
+  if (!empty($form_values['depth'])) {
+    $cultivation_depth = array(
+      'measure' => 'length',
+      'value' => $form_values['depth'],
+      'units' => 'cm',
+    );
+    $measurements[] = $cultivation_depth;
+
+    // Build a log name with the cultivation measurement.
+    $args = array(
+      '@type' => $operation_task,
+      '@area' => entity_label('taxonomy_term', $area),
+      '@qty' => $cultivation_depth['value'],
+      '@units' => $cultivation_depth['units'],
+    );
+    $log_name = t('Operation: @type @qty @units in @area', $args);
+  }
+  // Else build the log name without cultivation measurement.
+  else {
+    $args = array(
+      '@type' => $operation_task,
+      '@area' => entity_label('taxonomy_term', $area),
+    );
+    $log_name = t('Operation: @type in @area', $args);
+  }
 
   // Create a new farm quantity log.
   $log = farm_quantity_log_create($log_type, $log_name, $timestamp, TRUE, array(), $measurements);


### PR DESCRIPTION
Bruce reported the following after the changes from #6 (which made the cultivation quickform work for "operations" more generally): 

> The log is still being created as a cultivation regardless of the activity e.g as below .. I created a baling event and is logged as ‘Cultivation: bailing’ which could be confusing for end users. It also has the cultivation depth set as a required field, regardless of the activity.

This PR makes two changes:
1. Change the log name prefix from `Cultivation: ...` to `Operation: ...`
2. Do not require the "Cultivation Depth" field.

It seems that the "Cultivation depth" field was required because the cultivation depth was being used in the log name. The current format is:
`Operation: {operation_type} {cultivation depth} {cultivation units} in {area}`.

I changed the log name so the `{cultivation_depth}` and  `{cultivation_units}` are only included when provided.

![flat_roll_example](https://user-images.githubusercontent.com/3116995/131543873-ab74b6bd-80c4-4d6b-9a6a-b9f7e7c0d802.png)
![plough_example](https://user-images.githubusercontent.com/3116995/131543876-1a1532e1-797f-409a-9ae0-6d447af3960c.png)
