### PR TITLE
Add description to the Depth worked field.

### DIFF
--- a/farm_rothamsted.farm_quick.cultivation.inc
+++ b/farm_rothamsted.farm_quick.cultivation.inc
@@ -76,6 +76,7 @@ function farm_rothamsted_cultivation_quick_form($form, &$form_state) {
   $form[$name]['depth'] = array(
     '#type' => 'textfield',
     '#title' => t('Depth worked (centimeters)'),
+    '#description' => t('Put "0" for surface cultivation (e.g. rolling) or leave blank if the operation does not relate to soil movement (e.g. mowing).'),
     '#input_group' => TRUE,
     '#field_suffix' => t('centimeters'),
     '#element_validate' => array('element_validate_number'),


### PR DESCRIPTION
From @aislinnpearson in https://github.com/Rothamsted-Ecoinformatics/farm_rothamsted/pull/6#issuecomment-910077434:

> This all looks really good, thanks so much! The other change that Bruce requested in my follow up conversation with him was to add this brief instruction under the "Depth Worked" header on the Operations quick form:

> “Put “0” for surface cultivation (e.g. rolling) or “NA” if the operation doesn’t relate to soil movement (e.g. mowing)”.

Done! In the description I changed "NA" to read "leave blank" since this is strictly a number field that is used in the activity log quantity. Is that OK? See the example screenshot below.

![depth-description](https://user-images.githubusercontent.com/3116995/132409352-46085e7c-d3d8-4c0d-b8fa-300dc2c61bbc.png)
