### PR TITLE
2.x - Only load "Justification/Target (Spray Applications)" log categories

### DIFF
--- a/src/Plugin/QuickForm/QuickSpraying.php
+++ b/src/Plugin/QuickForm/QuickSpraying.php
@@ -137,7 +137,7 @@ class QuickSpraying extends QuickExperimentFormBase {
     $justification_options = [];
     $log_categories = $this->entityTypeManager->getStorage('taxonomy_term')->loadByProperties([
       'vid' => 'log_category',
-      'name' => 'Spraying applications',
+      'name' => 'Justification/Target (Spray Applications)',
       'status' => 1,
     ]);
 

--- a/src/Plugin/QuickForm/QuickSpraying.php
+++ b/src/Plugin/QuickForm/QuickSpraying.php
@@ -134,23 +134,27 @@ class QuickSpraying extends QuickExperimentFormBase {
     ];
 
     // Build justification options from log categories.
+    $justification_options = [];
     $log_categories = $this->entityTypeManager->getStorage('taxonomy_term')->loadByProperties([
       'vid' => 'log_category',
       'name' => 'Spraying applications',
       'status' => 1,
     ]);
-    $sprayApps = reset($log_categories);
-    $sprayAppsTid = $sprayApps->get('tid')->value;
-    $log_categories = $this->entityTypeManager->getStorage('taxonomy_term')
-      ->loadChildren($sprayAppsTid);
-    $justification_options = [];
-    foreach ($log_categories as $term) {
-      $status = $term->get('status')->value;
-      if ($status) {
-        $justification_options[] = $term->label();
+
+    if (count($log_categories)) {
+      $sprayApps = reset($log_categories);
+      $sprayAppsTid = $sprayApps->get('tid')->value;
+      $log_categories = $this->entityTypeManager->getStorage('taxonomy_term')
+        ->loadChildren($sprayAppsTid);
+      foreach ($log_categories as $term) {
+        $status = $term->get('status')->value;
+        if ($status) {
+          $justification_options[] = $term->label();
+        }
       }
+      asort($justification_options);
     }
-    asort($justification_options);
+
     // Justification/Target as log categories.
     $form['categories'] = [
       '#type' => 'select',

--- a/src/Plugin/QuickForm/QuickSpraying.php
+++ b/src/Plugin/QuickForm/QuickSpraying.php
@@ -160,6 +160,7 @@ class QuickSpraying extends QuickExperimentFormBase {
       '#type' => 'select',
       '#title' => $this->t('Justification/Target'),
       '#options' => $justification_options,
+      '#multiple' => TRUE,
       '#weight' => 16,
     ];
 

--- a/src/Plugin/QuickForm/QuickSpraying.php
+++ b/src/Plugin/QuickForm/QuickSpraying.php
@@ -3,7 +3,6 @@
 namespace Drupal\farm_rothamsted\Plugin\QuickForm;
 
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\taxonomy\TermInterface;
 
 /**
  * Spraying quick form.
@@ -137,12 +136,21 @@ class QuickSpraying extends QuickExperimentFormBase {
     // Build justification options from log categories.
     $log_categories = $this->entityTypeManager->getStorage('taxonomy_term')->loadByProperties([
       'vid' => 'log_category',
+      'name' => 'Spraying applications',
       'status' => 1,
     ]);
-    $justification_options = array_map(function (TermInterface $term) {
-      return $term->label();
-    }, $log_categories);
-
+    $sprayApps = reset($log_categories);
+    $sprayAppsTid = $sprayApps->get('tid')->value;
+    $log_categories = $this->entityTypeManager->getStorage('taxonomy_term')
+      ->loadChildren($sprayAppsTid);
+    $justification_options = [];
+    foreach ($log_categories as $term) {
+      $status = $term->get('status')->value;
+      if ($status) {
+        $justification_options[] = $term->label();
+      }
+    }
+    asort($justification_options);
     // Justification/Target as log categories.
     $form['categories'] = [
       '#type' => 'select',


### PR DESCRIPTION
I have hard-coded the filter name "Spraying applications" in line 139 - I am not sure this is what we want to do as an end goal but it is currently working.
@paul121 any better ideas?