### PR TITLE
Ensure generated elements remain unique to fulfil submission

### DIFF
--- a/src/Plugin/QuickForm/QuickDrilling.php
+++ b/src/Plugin/QuickForm/QuickDrilling.php
@@ -100,7 +100,7 @@ class QuickDrilling extends QuickExperimentFormBase {
       '#required' => FALSE,
       '#units_type' => 'select',
       '#units_options' => $target_plant_population_units_options,
-    ]);
+    ], 'target_plant_population');
 
     // Establishment average units options.
     $establishment_average_units_options = [
@@ -116,7 +116,7 @@ class QuickDrilling extends QuickExperimentFormBase {
       '#required' => FALSE,
       '#units_type' => 'select',
       '#units_options' => $establishment_average_units_options,
-    ]);
+    ], 'establishment_average');
 
     // Germination rate.
     $drilling['germination_rate'] = [
@@ -150,7 +150,7 @@ class QuickDrilling extends QuickExperimentFormBase {
       '#required' => TRUE,
       '#units_type' => 'select',
       '#units_options' => $seed_rate_units_options,
-    ]);
+    ], 'seed_rate');
 
     // Drilling rate.
     $drilling['drilling_rate'] = [
@@ -216,7 +216,7 @@ class QuickDrilling extends QuickExperimentFormBase {
       '#required' => FALSE,
       '#units_type' => 'select',
       '#units_options' => $product_application_rate_units_options,
-    ]);
+    ], 'product_application_rate');
 
     // Seed lineage options.
     $seed_lineage_options = [

--- a/src/Plugin/QuickForm/QuickExperimentFormBase.php
+++ b/src/Plugin/QuickForm/QuickExperimentFormBase.php
@@ -118,10 +118,13 @@ abstract class QuickExperimentFormBase extends QuickFormBase {
    *     '#units_type' => 'select' or 'radios'
    *     '#units_options' => options array as per core.
    *
+   * @param string $name
+   *   String name used to submit element - units is appended for unit element
+   *
    * @return array
    *   An array containing both form elements within wrapper to keep inline
    */
-  protected function buildQuantityUnitsElement(array $config) {
+  protected function buildQuantityUnitsElement(array $config, string $name = 'abc') {
 
     // Flex container wrapper.
     $element = [
@@ -139,16 +142,18 @@ abstract class QuickExperimentFormBase extends QuickFormBase {
     }
 
     // Main quantity element.
-    $element['quantity'] = $config;
+    $element[$name] = $config;
+
+    $unitsName = sprintf('%s_units', $name);
 
     // Units.
     if (isset($config['#units_options'])) {
-      $element['units'] = [];
-      $element['units']['#type'] = (isset($config['#units_type'])) ? $config['#units_type'] : 'select';
-      $element['units']['#title'] = $this->t('Units');
-      $element['units']['#options'] = $config['#units_options'];
-      $element['units']['#required'] = $config['#required'] ?? FALSE;
-      $element['units']['#validated'] = TRUE;
+      $element[$unitsName] = [];
+      $element[$unitsName]['#type'] = (isset($config['#units_type'])) ? $config['#units_type'] : 'select';
+      $element[$unitsName]['#title'] = $this->t('Units');
+      $element[$unitsName]['#options'] = $config['#units_options'];
+      $element[$unitsName]['#required'] = $config['#required'] ?? FALSE;
+      $element[$unitsName]['#validated'] = TRUE;
     }
 
     return $element;
@@ -296,7 +301,7 @@ abstract class QuickExperimentFormBase extends QuickFormBase {
       '#type' => 'number',
       '#units_type' => 'select',
       '#units_options' => $fuel_use_units_options,
-    ]);
+    ], 'fuel_use');
 
     // Photographs wrapper.
     $form['operation']['photographs'] = $this->buildInlineWrapper();

--- a/src/Plugin/QuickForm/QuickFertiliser.php
+++ b/src/Plugin/QuickForm/QuickFertiliser.php
@@ -149,7 +149,7 @@ class QuickFertiliser extends QuickExperimentFormBase {
         '#required' => FALSE,
         '#units_type' => 'select',
         '#units_options' => $application_rate_units_options,
-      ]);
+      ], 'nutrient_application_rate');
 
       // Product application rate - number - required.
       $fertiliser['nutrient_input']['nutrients'][$i]['product_application_rate'] = $this->buildQuantityUnitsElement([
@@ -159,7 +159,7 @@ class QuickFertiliser extends QuickExperimentFormBase {
         '#required' => TRUE,
         '#units_type' => 'select',
         '#units_options' => $application_rate_units_options,
-      ]);
+      ], 'product_application_rate');
 
       // Product area - number - required.
       $fertiliser['nutrient_input']['nutrients'][$i]['product_area'] = [
@@ -182,7 +182,7 @@ class QuickFertiliser extends QuickExperimentFormBase {
         '#required' => TRUE,
         '#units_type' => 'select',
         '#units_options' => $application_volume_units_options,
-      ]);
+      ], 'product_volume');
 
     }
 

--- a/src/Plugin/QuickForm/QuickSpraying.php
+++ b/src/Plugin/QuickForm/QuickSpraying.php
@@ -135,7 +135,7 @@ class QuickSpraying extends QuickExperimentFormBase {
         '#required' => TRUE,
         '#units_type' => 'select',
         '#units_options' => $product_rate_unit_options,
-      ]);
+      ], 'sprayed_products');
 
     }
     // ------------end of product area --------------------
@@ -172,7 +172,7 @@ class QuickSpraying extends QuickExperimentFormBase {
       '#required' => FALSE,
       '#units_type' => 'select',
       '#units_options' => $area_sprayed_units_options,
-    ]);
+    ], 'area_sprayed');
 
     // RRES product number.
     $spraying['rres_product_number'] = [
@@ -198,7 +198,7 @@ class QuickSpraying extends QuickExperimentFormBase {
       '#required' => TRUE,
       '#units_type' => 'select',
       '#units_options' => $product_quantity_units_options,
-    ]);
+    ], 'product_quantity');
 
     // Water volume units options.
     $water_volume_units_options = [
@@ -214,7 +214,7 @@ class QuickSpraying extends QuickExperimentFormBase {
       '#required' => TRUE,
       '#units_type' => 'select',
       '#units_options' => $water_volume_units_options,
-    ]);
+    ], 'water_volume');
 
     // Plant growth stage.
     $spraying['plant_growth_stage'] = [
@@ -312,7 +312,7 @@ class QuickSpraying extends QuickExperimentFormBase {
       '#required' => FALSE,
       '#units_type' => 'select',
       '#units_options' => $tank_volume_ramaining_units_options,
-    ]);
+    ], 'tank_volume_remaining');
 
     // Equipment triple Rinsed.
     $tank['rinsed'] = [
@@ -346,7 +346,7 @@ class QuickSpraying extends QuickExperimentFormBase {
       '#required' => TRUE,
       '#units_type' => 'select',
       '#units_options' => $wind_speed_units_options,
-    ]);
+    ], 'wind_speed');
 
     // Wind direction.
     $wind_directions = [
@@ -422,7 +422,7 @@ class QuickSpraying extends QuickExperimentFormBase {
       '#required' => FALSE,
       '#units_type' => 'select',
       '#units_options' => $speed_driven_units_options,
-    ]);
+    ], 'speed_driven');
 
     // Add the operation tab and fields to the form.
     $form['operation'] = $operation;


### PR DESCRIPTION
As an interim measure I have added a parameter to specify the form element name so the method can generate id fields and keep all elements identifiable in submission.

For example: "fuel_use" will generate two elements:

```
fuel_use
fuel_use_units
```

The intention is still to create a form element more aligned to other elements, but this solution is a quick / dirty solution to allow coding of the submission unblocked.