### PR TITLE
Harvest storage location

### DIFF
--- a/farm_rothamsted.module
+++ b/farm_rothamsted.module
@@ -19,6 +19,25 @@ use Drupal\system\Entity\Action;
 function farm_rothamsted_farm_entity_bundle_field_info(EntityTypeInterface $entity_type, string $bundle) {
   $fields = [];
 
+  // Add fields to harvest logs.
+  if ($entity_type->id() === 'log' && $bundle === 'harvest') {
+
+    // Add storage_location field.
+    $field_info = [
+      'type' => 'entity_reference',
+      'label' => t('Storage location'),
+      'description' => t('The harvest storage location.'),
+      'target_type' => 'asset',
+      'target_bundle' => 'structure',
+      'multiple' => TRUE,
+      'weight' => [
+        'form' => 90,
+        'view' => 90,
+      ],
+    ];
+    $fields['storage_location'] = \Drupal::service('farm_field.factory')->bundleFieldDefinition($field_info);
+  }
+
   // Add fields to input logs.
   if ($entity_type->id() === 'log' && $bundle === 'input') {
 

--- a/farm_rothamsted.post_update.php
+++ b/farm_rothamsted.post_update.php
@@ -25,4 +25,36 @@ function farm_rothamsted_post_update_add_harvest_storage_location_field(&$sandbo
   ];
   $field_definition = \Drupal::service('farm_field.factory')->bundleFieldDefinition($field_info);
   \Drupal::entityDefinitionUpdateManager()->installFieldStorageDefinition('storage_location', 'log', 'farm_rothamsted', $field_definition);
+
+  // Update trailer harvest logs to use the storage_location field.
+  $trailer_harvest_logs = \Drupal::entityTypeManager()->getStorage('log')->loadByProperties([
+    'quick' => 'trailer_harvest',
+    'location.entity:asset.type' => 'structure',
+  ]);
+  foreach ($trailer_harvest_logs as $log) {
+
+    // Get location field objects.
+    /** @var \Drupal\Core\Field\EntityReferenceFieldItemListInterface $log_location */
+    $log_location = $log->get('location');
+    /** @var \Drupal\Core\Field\EntityReferenceFieldItemListInterface $log_storage_location */
+    $log_storage_location = $log->get('storage_location');
+
+    // Move structure assets in the locations field to storage_locations field.
+    $locations = [];
+    $storage_locations = [];
+    foreach ($log_location->referencedEntities() as $asset) {
+      if ($asset->bundle() === 'structure') {
+        $storage_locations[] = $asset;
+      }
+      else {
+        $locations[] = $asset;
+      }
+    }
+
+    // Update both fields and save log.
+    $log_location->setValue($locations);
+    $log_storage_location->setValue($storage_locations);
+    $log->save();
+  }
+
 }

--- a/farm_rothamsted.post_update.php
+++ b/farm_rothamsted.post_update.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * @file
+ * Update hooks for farm_rothamsted.module.
+ */
+
+/**
+ * Add storage_location field to harvest logs.
+ */
+function farm_rothamsted_post_update_add_harvest_storage_location_field(&$sandbox = NULL) {
+
+  // Add storage_location field.
+  $field_info = [
+    'type' => 'entity_reference',
+    'label' => t('Storage location'),
+    'description' => t('The harvest storage location.'),
+    'target_type' => 'asset',
+    'target_bundle' => 'structure',
+    'multiple' => TRUE,
+    'weight' => [
+      'form' => 90,
+      'view' => 90,
+    ],
+  ];
+  $field_definition = \Drupal::service('farm_field.factory')->bundleFieldDefinition($field_info);
+  \Drupal::entityDefinitionUpdateManager()->installFieldStorageDefinition('storage_location', 'log', 'farm_rothamsted', $field_definition);
+}

--- a/modules/farm_rothamsted_quick/src/Plugin/QuickForm/QuickTrailerHarvest.php
+++ b/modules/farm_rothamsted_quick/src/Plugin/QuickForm/QuickTrailerHarvest.php
@@ -223,7 +223,7 @@ class QuickTrailerHarvest extends QuickExperimentFormBase {
     $log = parent::prepareLog($form, $form_state);
 
     // Include the storage location.
-    $log['location'] = $form_state->getValue('storage_location');
+    $log['storage_location'] = $form_state->getValue('storage_location');
 
     return $log;
   }


### PR DESCRIPTION
See #192 

This does a few things:
- Adds a `storage_location` field to harvest logs and implements `hook_post_update_NAME` in `farm_rothamsted.post_update.php`
- Updates existing `trailer_harvest` logs to move the structure assets to the new `storage_location` field
- Updates trailer harvest quick form to use the new `storage_location` field.

Requesting review from @mstenta regarding this update hook