### PR TITLE
2.x quick prepopulate

### DIFF
--- a/modules/farm_rothamsted_quick/config/install/views.view.rothamsted_quick_logs.yml
+++ b/modules/farm_rothamsted_quick/config/install/views.view.rothamsted_quick_logs.yml
@@ -1,0 +1,1409 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.log_category
+  module:
+    - log
+    - options
+    - state_machine
+    - taxonomy
+    - user
+  enforced:
+    module:
+      - farm_ui_views
+id: rothamsted_quick_logs
+label: rothamsted_quick_logs
+module: views
+description: ''
+tag: ''
+base_table: log_field_data
+base_field: id
+display:
+  default:
+    id: default
+    display_title: Master
+    display_plugin: default
+    position: 0
+    display_options:
+      title: Logs
+      fields:
+        id:
+          id: id
+          table: log_field_data
+          field: id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: log
+          entity_field: id
+          plugin_id: field
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        nothing:
+          id: nothing
+          table: views
+          field: nothing
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: custom
+          label: 'Copy link'
+          exclude: true
+          alter:
+            alter_text: true
+            text: Copy
+            make_link: true
+            path: 'quick/{{ arguments.quick_value }}?log={{ id }}'
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: false
+        dropbutton:
+          id: dropbutton
+          table: views
+          field: dropbutton
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: dropbutton
+          label: Action
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          destination: false
+          fields:
+            nothing: nothing
+            id: '0'
+        status:
+          id: status
+          table: log_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: log
+          entity_field: status
+          plugin_id: field
+          label: Status
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: list_default
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        timestamp:
+          id: timestamp
+          table: log_field_data
+          field: timestamp
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: log
+          entity_field: timestamp
+          plugin_id: log_field
+          label: Timestamp
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: true
+            path: 'log/{{ id }}'
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: timestamp
+          settings:
+            date_format: html_date
+            custom_date_format: ''
+            timezone: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        name:
+          id: name
+          table: log_field_data
+          field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: name
+          plugin_id: field
+          label: 'Log name'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        asset_target_id:
+          id: asset_target_id
+          table: log__asset
+          field: asset_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: log
+          entity_field: asset
+          plugin_id: field
+          label: Assets
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: true
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        location_target_id:
+          id: location_target_id
+          table: log__location
+          field: location_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: log
+          entity_field: location
+          plugin_id: field
+          label: Location
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: true
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        flag_value:
+          id: flag_value
+          table: log__flag
+          field: flag_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: log
+          entity_field: flag
+          plugin_id: field
+          label: Flags
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: list_default
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: true
+        category_target_id:
+          id: category_target_id
+          table: log__category
+          field: category_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: log
+          entity_field: category
+          plugin_id: field
+          label: 'Log category'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        owner_target_id:
+          id: owner_target_id
+          table: log__owner
+          field: owner_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: log
+          entity_field: owner
+          plugin_id: field
+          label: 'Assigned to'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: true
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      pager:
+        type: full
+        options:
+          offset: 0
+          items_per_page: 50
+          total_pages: null
+          id: 0
+          tags:
+            next: ››
+            previous: ‹‹
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: true
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '25, 50, 100, 250, 500'
+            items_per_page_options_all: true
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: true
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'view any log'
+      cache:
+        type: tag
+        options: {  }
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text_custom
+          empty: true
+          content: 'No logs found.'
+          tokenize: false
+      sorts: {  }
+      arguments:
+        quick_value:
+          id: quick_value
+          table: log__quick
+          field: quick_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: log
+          entity_field: quick
+          plugin_id: string
+          default_action: 'not found'
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: true
+          title: '{{ arguments.quick_value }} logs'
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          glossary: false
+          limit: 0
+          case: none
+          path_case: none
+          transform_dash: false
+          break_phrase: false
+      filters:
+        name:
+          id: name
+          table: log_field_data
+          field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: log
+          entity_field: name
+          plugin_id: string
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: name_op
+            label: 'Log name'
+            description: ''
+            use_operator: false
+            operator: name_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: name
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        category_target_id:
+          id: category_target_id
+          table: log__category
+          field: category_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: log
+          entity_field: category
+          plugin_id: taxonomy_index_tid
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: category_target_id_op
+            label: 'Log category'
+            description: ''
+            use_operator: false
+            operator: category_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: category_target_id
+            required: false
+            remember: false
+            multiple: true
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          vid: log_category
+          type: select
+          hierarchy: false
+          limit: true
+          error_message: true
+        flag_value:
+          id: flag_value
+          table: log__flag
+          field: flag_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: log
+          entity_field: flag
+          plugin_id: list_field
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: flag_value_op
+            label: Flags
+            description: ''
+            use_operator: false
+            operator: flag_value_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: flag_value
+            required: false
+            remember: false
+            multiple: true
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+        timestamp:
+          id: timestamp
+          table: log_field_data
+          field: timestamp
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: log
+          entity_field: timestamp
+          plugin_id: date
+          operator: '>='
+          value:
+            min: ''
+            max: ''
+            value: ''
+            type: date
+          group: 1
+          exposed: true
+          expose:
+            operator_id: timestamp_op
+            label: 'Start date'
+            description: ''
+            use_operator: false
+            operator: timestamp_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: start
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            min_placeholder: ''
+            max_placeholder: ''
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        timestamp_1:
+          id: timestamp_1
+          table: log_field_data
+          field: timestamp
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: log
+          entity_field: timestamp
+          plugin_id: date
+          operator: '<='
+          value:
+            min: ''
+            max: ''
+            value: ''
+            type: date
+          group: 1
+          exposed: true
+          expose:
+            operator_id: timestamp_1_op
+            label: 'End date'
+            description: ''
+            use_operator: false
+            operator: timestamp_1_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: end
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            min_placeholder: ''
+            max_placeholder: ''
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        status:
+          id: status
+          table: log_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: log
+          entity_field: status
+          plugin_id: state_machine_state
+          operator: in
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: status_op
+            label: Status
+            description: ''
+            use_operator: false
+            operator: status_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: status
+            required: false
+            remember: false
+            multiple: true
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        owner_target_id:
+          id: owner_target_id
+          table: log__owner
+          field: owner_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: log
+          entity_field: owner
+          plugin_id: entity_reference
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: owner_target_id_op
+            label: 'Assigned to'
+            description: ''
+            use_operator: false
+            operator: owner_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: owner_target_id
+            required: false
+            remember: false
+            multiple: true
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          handler: views
+          widget: select
+          handler_settings:
+            view:
+              view_name: farm_people
+              display_name: entity_reference
+              arguments: {  }
+        asset_target_id:
+          id: asset_target_id
+          table: log__asset
+          field: asset_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: log
+          entity_field: asset
+          plugin_id: entity_reference
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: asset_target_id_op
+            label: Assets
+            description: ''
+            use_operator: false
+            operator: asset_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: asset_target_id
+            required: false
+            remember: false
+            multiple: true
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          handler: views
+          widget: autocomplete
+          handler_settings:
+            view:
+              view_name: farm_asset_reference
+              display_name: entity_reference
+              arguments: {  }
+        location_target_id:
+          id: location_target_id
+          table: log__location
+          field: location_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: log
+          entity_field: location
+          plugin_id: entity_reference
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: location_target_id_op
+            label: Location
+            description: ''
+            use_operator: false
+            operator: location_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: location_target_id
+            required: false
+            remember: false
+            multiple: true
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          handler: views
+          widget: autocomplete
+          handler_settings:
+            view:
+              view_name: farm_location_reference
+              display_name: entity_reference
+              arguments: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          columns:
+            log_bulk_form: log_bulk_form
+            status: status
+            id: id
+            timestamp: timestamp
+            name: name
+            type: type
+            asset_target_id: asset_target_id
+            location_target_id: location_target_id
+            quantity_target_id: quantity_target_id
+            flag_value: flag_value
+            category_target_id: category_target_id
+            owner_target_id: owner_target_id
+          default: timestamp
+          info:
+            log_bulk_form:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            status:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            id:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            timestamp:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            name:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            type:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            asset_target_id:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            location_target_id:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            quantity_target_id:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            flag_value:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            category_target_id:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            owner_target_id:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          override: true
+          sticky: false
+          summary: ''
+          empty_table: true
+          caption: ''
+          description: ''
+      row:
+        type: fields
+        options:
+          default_field_elements: true
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      use_ajax: true
+      use_more: false
+      use_more_always: false
+      use_more_text: more
+      header: {  }
+      footer:
+        result:
+          id: result
+          table: views
+          field: result
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: result
+          empty: false
+          content: 'Displaying @start - @end of @total'
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user
+        - user.permissions
+      tags: {  }
+  page:
+    id: page
+    display_title: 'All logs (page)'
+    display_plugin: page
+    position: 1
+    display_options:
+      defaults:
+        footer: false
+      display_description: ''
+      footer:
+        result:
+          id: result
+          table: views
+          field: result
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: result
+          empty: false
+          content: 'Displaying @start - @end of @total'
+      display_extenders: {  }
+      path: quick/%quick_form_id/logs
+      menu:
+        type: none
+        title: ''
+        description: ''
+        weight: 0
+        expanded: false
+        menu_name: admin
+        parent: farm.records
+        context: '0'
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user
+        - user.permissions
+      tags: {  }

--- a/modules/farm_rothamsted_quick/farm_rothamsted_quick.info.yml
+++ b/modules/farm_rothamsted_quick/farm_rothamsted_quick.info.yml
@@ -11,3 +11,4 @@ dependencies:
   - farm_quantity_material
   - farm_quick
   - farm_rothamsted:farm_rothamsted
+  - views

--- a/modules/farm_rothamsted_quick/farm_rothamsted_quick.links.action.yml
+++ b/modules/farm_rothamsted_quick/farm_rothamsted_quick.links.action.yml
@@ -1,0 +1,13 @@
+farm_rothamsted_quick.trailer_harvest.prepopulate:
+  title: 'Prepopulate'
+  route_name: view.rothamsted_quick_logs.page
+  route_parameters:
+    quick_form_id: 'trailer_harvest'
+  appears_on:
+    - farm.quick.trailer_harvest
+  options:
+    attributes:
+      class:
+        - 'use-ajax'
+      data-dialog-type: 'modal'
+      data-dialog-options: '{"height": "auto", "width": "auto"}'

--- a/modules/farm_rothamsted_quick/farm_rothamsted_quick.post_update.php
+++ b/modules/farm_rothamsted_quick/farm_rothamsted_quick.post_update.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * @file
+ * Update hooks for farm_rothamsted.module.
+ */
+
+use Drupal\views\Entity\View;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Create rothamsted_quick_logs view.
+ */
+function farm_rothamsted_quick_post_update_create_rothamsted_quick_logs_view(&$sandbox = NULL) {
+
+  // Only create the view if views is enabled.
+  $view_id = 'rothamsted_quick_logs';
+  if (\Drupal::moduleHandler()->moduleExists('views') && !View::load($view_id)) {
+    $config_path = \Drupal::service('extension.list.module')->getPath('farm_rothamsted_quick') . "/config/install/views.view.$view_id.yml";
+    $data = Yaml::parseFile($config_path);
+    \Drupal::configFactory()->getEditable("views.view.$view_id")->setData($data)->save(TRUE);
+  }
+}

--- a/modules/farm_rothamsted_quick/farm_rothamsted_quick.views_execution.inc
+++ b/modules/farm_rothamsted_quick/farm_rothamsted_quick.views_execution.inc
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * @file
+ * Provides Views runtime hooks for farm_rothamsted_quick.module.
+ */
+
+use Drupal\views\Plugin\views\cache\CachePluginBase;
+use Drupal\views\ViewExecutable;
+
+/**
+ * Implements hook_views_post_render().
+ */
+function farm_rothamsted_quick_views_post_render(ViewExecutable $view, array &$output, CachePluginBase $cache) {
+
+  // Modify the title of the rothamsted_quick_logs view.
+  // Workaround for https://www.drupal.org/project/drupal/issues/2663316
+  if ($view->id() == 'rothamsted_quick_logs') {
+
+    // In the future, we should add a views argument plugin for quick forms
+    // and use this plugin to get the quick form title.
+    $title = $view->getTitle();
+    $output['#title'] = ucfirst(str_replace('_', ' ', $title));
+  }
+
+}

--- a/modules/farm_rothamsted_quick/src/Plugin/QuickForm/QuickExperimentFormBase.php
+++ b/modules/farm_rothamsted_quick/src/Plugin/QuickForm/QuickExperimentFormBase.php
@@ -22,6 +22,7 @@ use Drupal\farm_rothamsted_quick\Traits\QuickTaxonomyOptionsTrait;
 use Drupal\taxonomy\Entity\Term;
 use Drupal\user\UserInterface;
 use Psr\Container\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Base class for experiment plan quick forms.
@@ -106,6 +107,13 @@ abstract class QuickExperimentFormBase extends QuickFormBase {
   protected $productBatchNum = FALSE;
 
   /**
+   * Default values to use when initializing the form.
+   *
+   * @var array
+   */
+  protected $defaultValues = [];
+
+  /**
    * Constructs a QuickFormBase object.
    *
    * @param array $configuration
@@ -149,6 +157,9 @@ abstract class QuickExperimentFormBase extends QuickFormBase {
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
+
+    // First build default values from the request.
+    $this->buildDefaults(\Drupal::request());
 
     // Define base quick form tabs.
     $form['tabs'] = [
@@ -620,6 +631,50 @@ abstract class QuickExperimentFormBase extends QuickFormBase {
 
     // Finally, create the log.
     $this->createLog($log);
+  }
+
+  /**
+   * Helper function to build form defaults.
+   *
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   The request.
+   */
+  protected function buildDefaults(Request $request) {
+
+    // Build common defaults if a log is provided.
+    if ($log_id = $request->get('log')) {
+
+      // Save the log.
+      $log = $this->entityTypeManager->getStorage('log')->load($log_id);
+      $this->defaultValues['log'] = $log;
+
+      // Assets.
+      $this->defaultValues['asset'] = $log->get('asset')->referencedEntities();
+
+      // Equipment assets.
+      $equipment = $log->get('equipment')->referencedEntities();
+      $equipment_ids = array_map(function (AssetInterface $asset) {
+        return $asset->id();
+      }, $equipment);
+
+      // Tractor.
+      $tractor_options = $this->getGroupMemberOptions(['Tractor Equipment'], ['equipment']);
+      $this->defaultValues['tractor'] = array_intersect($equipment_ids, array_keys($tractor_options));
+
+      // Machinery.
+      $machinery_options = $this->getGroupMemberOptions($this->machineryGroupNames, ['equipment']);
+      $this->defaultValues['machinery'] = array_intersect($equipment_ids, array_keys($machinery_options));
+
+      // Notes.
+      $this->defaultValues['notes'] = [];
+      if (($notes = $log->get('notes')->value) && $lines = explode(PHP_EOL, $notes)) {
+        foreach ($lines as $line) {
+          if (($parts = explode(':', $line)) && count($parts) == 2) {
+            $this->defaultValues['notes'][$parts[0]] = trim($parts[1]);
+          }
+        }
+      }
+    }
   }
 
   /**

--- a/modules/farm_rothamsted_quick/src/Plugin/QuickForm/QuickExperimentFormBase.php
+++ b/modules/farm_rothamsted_quick/src/Plugin/QuickForm/QuickExperimentFormBase.php
@@ -207,7 +207,7 @@ abstract class QuickExperimentFormBase extends QuickFormBase {
     ];
 
     // Load prepopulated assets.
-    $default_assets = $this->getPrepopulatedEntities('asset', $form_state);
+    $default_assets = $this->defaultValues['asset'] ?? $this->getPrepopulatedEntities('asset', $form_state);
 
     // The autocomplete_deluxe element expects the default value to
     // be the "Asset name (id), Asset 2 (id)".
@@ -262,6 +262,7 @@ abstract class QuickExperimentFormBase extends QuickFormBase {
         '#title' => $this->t('Tractor'),
         '#description' => $this->t('Select the tractor used for this operation. You can expand the list by assigning Equipment Assets to the group "Tractor Equipment".'),
         '#options' => $tractor_options,
+        '#default_value' => $this->defaultValues['tractor'] ?? NULL,
         '#required' => TRUE,
       ];
     }
@@ -275,6 +276,7 @@ abstract class QuickExperimentFormBase extends QuickFormBase {
         '#title' => $machinery_options_string,
         '#description' => $this->t('Select the equipment used for this operation. You can expand the list by assigning Equipment Assets to the group "@group_names". To select more than one hold down the CTRL button and select multiple.', ['@group_names' => $machinery_options_string]),
         '#options' => $equipment_options,
+        '#default_value' => $this->defaultValues['machinery'] ?? NULL,
         '#multiple' => TRUE,
         '#required' => TRUE,
       ];
@@ -285,6 +287,7 @@ abstract class QuickExperimentFormBase extends QuickFormBase {
       '#type' => 'textarea',
       '#title' => $this->t('Equipment Settings'),
       '#description' => $this->t('An option to include any notes on the specific equipment settings used.'),
+      '#default_value' => $this->defaultValues['notes']['Equipment Settings'] ?? NULL,
     ];
 
     // Recommendation Number - text - optional.

--- a/modules/farm_rothamsted_quick/src/Plugin/QuickForm/QuickTrailerHarvest.php
+++ b/modules/farm_rothamsted_quick/src/Plugin/QuickForm/QuickTrailerHarvest.php
@@ -66,6 +66,7 @@ class QuickTrailerHarvest extends QuickExperimentFormBase {
       '#type' => 'select',
       '#title' => $this->t('Type of harvest'),
       '#options' => array_combine($harvest_options, $harvest_options),
+      '#default_value' => $this->defaultValues['notes']['Type of harvest'] ?? NULL,
       '#required' => TRUE,
     ];
 


### PR DESCRIPTION
Implements an initial generic solution for #82:
 - Prepopulate default values from a log ID provided in a `log` query parameter. This covers common "operation" fields: asset, equipment (tractor and machinery) and log notes.
 - A table view of logs submitted by quick forms. This page can be accessed by any quick form at `/quick/{quick_form}/logs`.
 The view has a  "COPY" button that will redirect to the quick form to prepopulate values from the given log.
 
 And implements #209:
 - Adds a "Prepopulate" action link to open previous quick form logs in a modal.
 - Prepopulates all common "operation" fields as well as the `type_of_harvest` field specific to the Trailer harvest quick form.