### PR TITLE
2.9.3 fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Specify quick form quantities to be standard. [#359](https://github.com/Rothamsted-Ecoinformatics/farm_rothamsted/issues/359)
+- Update previously submitted material quantities to be standard. [#359](https://github.com/Rothamsted-Ecoinformatics/farm_rothamsted/issues/359)
 
 ## [2.9.2](https://github.com/Rothamsted-Ecoinformatics/farm_rothamsted/milestone/15) 2022-12-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Specify quick form quantities to be standard. [#359](https://github.com/Rothamsted-Ecoinformatics/farm_rothamsted/issues/359)
+
 ## [2.9.2](https://github.com/Rothamsted-Ecoinformatics/farm_rothamsted/milestone/15) 2022-12-12
 
 ### Fixed

--- a/modules/farm_rothamsted_quick/src/Plugin/QuickForm/QuickExperimentFormBase.php
+++ b/modules/farm_rothamsted_quick/src/Plugin/QuickForm/QuickExperimentFormBase.php
@@ -578,6 +578,7 @@ abstract class QuickExperimentFormBase extends QuickFormBase {
         $application_rate_units_options = $this->getChildTermOptionsByName('unit', 'Volume per unit area');
         $product_application_rate = [
           'title' => $this->t('Product rate'),
+          'type' => ['#value' => 'material'],
           'measure' => ['#value' => 'rate'],
           'units' => ['#options' => $application_rate_units_options],
           'required' => TRUE,
@@ -1220,6 +1221,7 @@ abstract class QuickExperimentFormBase extends QuickFormBase {
       $hours = $time_taken['hours'];
       $minutes = $time_taken['minutes'];
       $quantities[] = [
+        'type' => 'standard',
         'label' => (string) $this->t('Time taken'),
         'value' => $hours + $minutes / 60,
         'measure' => 'time',
@@ -1232,7 +1234,6 @@ abstract class QuickExperimentFormBase extends QuickFormBase {
       for ($i = 0; $i < $product_count; $i++) {
         $material = $form_state->getValue(['products', $i, 'product_wrapper', 'product']);
         $quantity = $form_state->getValue(['products', $i, 'product_rate']);
-        $quantity['type'] = 'material';
         $quantity['material_type'] = $material;
         $quantities[] = $quantity;
       }

--- a/modules/farm_rothamsted_quick/src/Plugin/QuickForm/QuickTrailerHarvest.php
+++ b/modules/farm_rothamsted_quick/src/Plugin/QuickForm/QuickTrailerHarvest.php
@@ -320,6 +320,7 @@ class QuickTrailerHarvest extends QuickExperimentFormBase {
 
     // Compute the trailer nett weight.
     $total_nett_weight = [
+      'type' => 'standard',
       'label' => 'Nett weight',
       'measure' => 'weight',
       'units' => NULL,

--- a/modules/farm_rothamsted_quick/src/Traits/QuickQuantityFieldTrait.php
+++ b/modules/farm_rothamsted_quick/src/Traits/QuickQuantityFieldTrait.php
@@ -43,6 +43,10 @@ trait QuickQuantityFieldTrait {
     // Default config.
     $default_config = [
       'border' => FALSE,
+      'type' => [
+        '#type' => 'hidden',
+        '#value' => 'standard',
+      ],
       'measure' => [
         '#type' => 'select',
         '#title' => $this->t('Measure'),
@@ -88,6 +92,7 @@ trait QuickQuantityFieldTrait {
     }
 
     // Include each quantity subfield.
+    $render['type'] = $config['type'];
     $render['measure'] = $config['measure'];
     $render['value'] = $config['value'];
     $render['label'] = $config['label'];


### PR DESCRIPTION
This PR is to fix https://github.com/Rothamsted-Ecoinformatics/farm_rothamsted/issues/359

> Option 2) Do a more more heavy-handed update to truly "convert" the type from these material quantities to be standard

I've implemented this option 2 that I described. It was easier than I initially thought it might be.. seems like we only need to update the quantity `type` in the `quantity` table. After running this update hook both the quantity views and log pages updated accordingly. Just want to make sure I'm not missing anything

I tested the update hook the following ways:

- Fresh install of farmOS w/ Rothamsted quick module. I submitted each of the problem quick forms one time to create excess material quantities in the db. I completed all possible quantity fields (required and option) for each quick form to ensure that the update hooks for everything. I ran the update hook and confirmed that the only remaining material quantities had a label of "Product type"
- Only update logs from quick forms: I manually created a drilling log with standard and material quantities eg: "Time taken" and ran the update hook, confirmed that the log's quantities were not touched.
- Only update quantities with given specified labels: I modified a drilling log submitted by the quickform to have an additional material quantity, ran the update hook and confirmed the material quantity was not changed.

I've also updated the quick forms to specify `standard` quantity type where they previously did not specify a type. This was a fairly simple change as the `QuickQuantityFieldTrait` has a helper for creating the quantity fieldsets and can add the `type` as an additional `hidden` property. There are only a few quantities created more programatically in the quick forms, but I checked and believe I caught all of them. After making this change I submitted all of the problem quick forms and confirmed that `standard` quantities were being created.