### PR TITLE
FarmOS Version update: Support Drupal 10 / farmOS v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
       }
   ],
   "require": {
-    "farmos/farmos": "^2.1",
+    "farmos/farmos": "^2.1 || ^3",
     "drupal/autocomplete_deluxe": "^2.0",
     "drupal/farm_rei": "^2.0@beta",
     "drupal/field_group": "^3.2",

--- a/farm_rothamsted.info.yml
+++ b/farm_rothamsted.info.yml
@@ -2,7 +2,7 @@ name: farmOS Rothamsted
 description: Custom farmOS features for Rothamsted Research.
 type: module
 package: farmOS Custom
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - farm_activity
   - farm_entity

--- a/modules/farm_rothamsted_dev/farm_rothamsted_dev.info.yml
+++ b/modules/farm_rothamsted_dev/farm_rothamsted_dev.info.yml
@@ -2,7 +2,7 @@ name: farmOS Rothamsted Development
 description: Development module for the Rothamsted module.
 type: module
 package: farmOS Custom
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - farm_rothamsted
   - farm_rothamsted_quick

--- a/modules/farm_rothamsted_experiment/farm_rothamsted_experiment.info.yml
+++ b/modules/farm_rothamsted_experiment/farm_rothamsted_experiment.info.yml
@@ -2,7 +2,7 @@ name: farmOS Rothamsted Experiment
 description: Experiment plan for Rothamsted Research.
 type: module
 package: farmOS Custom
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - drupal:link
   - drupal:datetime

--- a/modules/farm_rothamsted_experiment/farm_rothamsted_experiment.post_update.php
+++ b/modules/farm_rothamsted_experiment/farm_rothamsted_experiment.post_update.php
@@ -820,6 +820,7 @@ function farm_rothamsted_experiment_post_update_2_13_migrate_experiment_code_stu
 
     // Query the database for all experiment plans.
     $sandbox['plan_ids'] = array_values($plan_storage->getQuery()
+      ->accessCheck(FALSE)
       ->condition('type', 'rothamsted_experiment')
       ->execute());
 

--- a/modules/farm_rothamsted_experiment/src/Form/ExperimentPlotGeometryForm.php
+++ b/modules/farm_rothamsted_experiment/src/Form/ExperimentPlotGeometryForm.php
@@ -278,6 +278,7 @@ class ExperimentPlotGeometryForm extends ExperimentFormBase {
     // Query plots to update in this batch.
     $asset_storage = \Drupal::entityTypeManager()->getStorage('asset');
     $plot_ids = $asset_storage->getQuery()
+      ->accessCheck(TRUE)
       ->condition('type', 'plot')
       ->condition('status', 'active')
       ->condition('id', $plan_plot_query, 'IN')

--- a/modules/farm_rothamsted_experiment/src/Form/ExperimentVariableForm.php
+++ b/modules/farm_rothamsted_experiment/src/Form/ExperimentVariableForm.php
@@ -626,6 +626,7 @@ class ExperimentVariableForm extends ExperimentFormBase {
     // Query plots to update in this batch.
     $asset_storage = \Drupal::entityTypeManager()->getStorage('asset');
     $plot_ids = $asset_storage->getQuery()
+      ->accessCheck(TRUE)
       ->condition('type', 'plot')
       ->condition('status', 'active')
       ->condition('id', $plan_plot_query, 'IN')

--- a/modules/farm_rothamsted_experiment_research/farm_rothamsted_experiment_research.info.yml
+++ b/modules/farm_rothamsted_experiment_research/farm_rothamsted_experiment_research.info.yml
@@ -2,7 +2,7 @@ name: farmOS Rothamsted Research Experiment
 description: Rothamsted Research features for experiment plans.
 type: module
 package: farmOS Custom
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - drupal:comment
   - drupal:datetime

--- a/modules/farm_rothamsted_experiment_research/farm_rothamsted_experiment_research.module
+++ b/modules/farm_rothamsted_experiment_research/farm_rothamsted_experiment_research.module
@@ -588,6 +588,7 @@ function farm_rothamsted_experiment_research_entity_insert(EntityInterface $enti
       }
 
       $query = \Drupal::entityTypeManager()->getStorage('plan')->getQuery()
+        ->accessCheck(TRUE)
         ->condition('type', 'rothamsted_experiment')
         ->condition('experiment_design.entity:rothamsted_design.experiment', NULL, 'IS NOT NULL');
       $or_group = $query->orConditionGroup()

--- a/modules/farm_rothamsted_experiment_research/src/Controller/RelatedEntities.php
+++ b/modules/farm_rothamsted_experiment_research/src/Controller/RelatedEntities.php
@@ -48,6 +48,7 @@ class RelatedEntities extends ControllerBase {
     // If view access check for existing plan relationship.
     if ($access->isAllowed()) {
       $plan_query = $this->entityTypeManager()->getStorage('plan')->getAggregateQuery()
+        ->accessCheck(TRUE)
         ->condition('type', 'rothamsted_experiment');
       $or_group = $plan_query->orConditionGroup()
         ->condition('asset', $asset->id())
@@ -72,6 +73,7 @@ class RelatedEntities extends ControllerBase {
   public function assetRelationships(AssetInterface $asset): array {
 
     $plan_query = $this->entityTypeManager()->getStorage('plan')->getQuery()
+      ->accessCheck(TRUE)
       ->condition('type', 'rothamsted_experiment');
 
     $or_group = $plan_query->orConditionGroup()

--- a/modules/farm_rothamsted_experiment_research/src/Plugin/Validation/Constraint/RothamstedStatusConstraint.php
+++ b/modules/farm_rothamsted_experiment_research/src/Plugin/Validation/Constraint/RothamstedStatusConstraint.php
@@ -43,7 +43,7 @@ class RothamstedStatusConstraint extends Constraint {
   /**
    * {@inheritDoc}
    */
-  public function __get($option) {
+  public function __get($option): mixed {
     if ('requiredStatuses' === $option) {
       return $this->requiredStatuses;
     }

--- a/modules/farm_rothamsted_notification/farm_rothamsted_notification.info.yml
+++ b/modules/farm_rothamsted_notification/farm_rothamsted_notification.info.yml
@@ -2,4 +2,4 @@ name: farmOS Rothamsted Notification
 description: Rothamsted Notification Features
 type: module
 package: farmOS Custom
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10

--- a/modules/farm_rothamsted_quick/farm_rothamsted_quick.info.yml
+++ b/modules/farm_rothamsted_quick/farm_rothamsted_quick.info.yml
@@ -2,7 +2,7 @@ name: farmOS Rothamsted Quick Forms
 description: Custom Quick Forms for Rothamsted Research.
 type: module
 package: farmOS Custom
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - autocomplete_deluxe:autocomplete_deluxe
   - farm_activity

--- a/modules/farm_rothamsted_quick/farm_rothamsted_quick.post_update.php
+++ b/modules/farm_rothamsted_quick/farm_rothamsted_quick.post_update.php
@@ -52,6 +52,7 @@ function farm_rothamsted_quick_post_update_log_categories_288(&$sandbox = NULL) 
 
     // Query logs submitted for the quick form that contain the notes value.
     $logs = $log_storage->getQuery()
+      ->accessCheck(FALSE)
       ->condition('quick', $quick_id)
       ->condition('notes.value', $notes_query, 'CONTAINS')
       ->execute();
@@ -105,6 +106,7 @@ function farm_rothamsted_quick_post_update_seed_dressing_notes_2(&$sandbox = NUL
   // Query logs submitted for the quick form that contain the notes value.
   $notes_query = 'Seed dressings:';
   $logs = $log_storage->getQuery()
+    ->accessCheck(FALSE)
     ->condition('quick', 'drilling')
     ->condition('notes.value', $notes_query, 'CONTAINS')
     ->execute();

--- a/modules/farm_rothamsted_quick/src/Plugin/QuickForm/QuickExperimentFormBase.php
+++ b/modules/farm_rothamsted_quick/src/Plugin/QuickForm/QuickExperimentFormBase.php
@@ -860,7 +860,7 @@ abstract class QuickExperimentFormBase extends QuickFormBase {
     // Load the temp store for the quick form.
     /** @var \Drupal\Core\TempStore\PrivateTempStoreFactory $temp_store_factory */
     $temp_store_factory = \Drupal::service('tempstore.private');
-    $temp_store = $temp_store_factory->get('farm_quick.' . $this->getId());
+    $temp_store = $temp_store_factory->get('farm_quick.' . $this->getQuickId());
 
     // Load entities from the temp store.
     $temp_store_key = $user->id() . ':' . $entity_type;
@@ -926,7 +926,7 @@ abstract class QuickExperimentFormBase extends QuickFormBase {
     // Load the temp store for the quick form.
     /** @var \Drupal\Core\TempStore\PrivateTempStoreFactory $temp_store_factory */
     $temp_store_factory = \Drupal::service('tempstore.private');
-    $temp_store = $temp_store_factory->get('farm_quick.' . $this->getId());
+    $temp_store = $temp_store_factory->get('farm_quick.' . $this->getQuickId());
 
     // Finally, remove the entities from the temp store.
     $user = \Drupal::currentUser();

--- a/modules/farm_rothamsted_quick/src/Plugin/QuickForm/QuickExperimentFormBase.php
+++ b/modules/farm_rothamsted_quick/src/Plugin/QuickForm/QuickExperimentFormBase.php
@@ -297,6 +297,7 @@ abstract class QuickExperimentFormBase extends QuickFormBase {
         // Start a query for active plant or experiment_boundary land assets
         // in the selected location(s).
         $asset_query = $this->entityTypeManager->getStorage('asset')->getQuery()
+          ->accessCheck(TRUE)
           ->condition('status', 'archived', '!=');
 
         // Limit to certain asset types.
@@ -328,6 +329,7 @@ abstract class QuickExperimentFormBase extends QuickFormBase {
         // assets have a parent that is not a location.
         // Do not include plot assets for performance reasons.
         $location_asset_query = $this->entityTypeManager->getStorage('asset')->getQuery()
+          ->accessCheck(TRUE)
           ->condition('status', 'archived', '!=')
           ->condition('type', 'plot', '!=');
         $location_condition = $location_asset_query->orConditionGroup()

--- a/modules/farm_rothamsted_researcher/farm_rothamsted_researcher.info.yml
+++ b/modules/farm_rothamsted_researcher/farm_rothamsted_researcher.info.yml
@@ -2,7 +2,7 @@ name: farmOS Rothamsted Researcher
 description: Adds a Researcher entity for Rothamsted Research.
 type: module
 package: farmOS Custom
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - farm:farm_ui_menu
   - farm_rothamsted:farm_rothamsted

--- a/modules/farm_rothamsted_roles/farm_rothamsted_roles.info.yml
+++ b/modules/farm_rothamsted_roles/farm_rothamsted_roles.info.yml
@@ -2,7 +2,7 @@ name: farmOS Rothamsted Roles
 description: Adds roles specific to Rothamsted Research
 type: module
 package: farmOS Custom
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - farm_role
   - farm_role_account_admin


### PR DESCRIPTION
Starting this draft PR to update the Rothamsted modules for Drupal 10 / farmOS v3.

This only makes the changes to `.info.yml` files and `composer.json`.

There is more to do, according to PHPStan:

```
$ sudo docker exec -it -u www-data farmos-www-1 vendor/bin/phpstan analyze /opt/drupal/web/sites/all/modules/farm_rothamsted
Note: Using configuration file /opt/drupal/phpstan.neon.
 72/72 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

 ------ ------------------------------------------------------------ 
  Line   farm_rothamsted.module                                      
 ------ ------------------------------------------------------------ 
  147    Variable $asset in empty() always exists and is not falsy.  
 ------ ------------------------------------------------------------ 

 ------ ----------------------------------------------------------------------------------------------------------------------------------------- 
  Line   modules/farm_rothamsted_experiment/farm_rothamsted_experiment.post_update.php                                                            
 ------ ----------------------------------------------------------------------------------------------------------------------------------------- 
  821    Relying on entity queries to check access by default is deprecated in drupal:9.2.0 and an error will be thrown from drupal:10.0.0. Call  
         \Drupal\Core\Entity\Query\QueryInterface::accessCheck() with TRUE or FALSE to specify whether access should be checked.                  
         💡 See https://www.drupal.org/node/3201242                                                                                               
 ------ ----------------------------------------------------------------------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------------------------------------------------------------------- 
  Line   modules/farm_rothamsted_experiment/src/Form/ExperimentPlotGeometryForm.php                                                               
 ------ ----------------------------------------------------------------------------------------------------------------------------------------- 
  156    \Drupal calls should be avoided in classes, use dependency injection instead                                                             
  161    \Drupal calls should be avoided in classes, use dependency injection instead                                                             
  263    Relying on entity queries to check access by default is deprecated in drupal:9.2.0 and an error will be thrown from drupal:10.0.0. Call  
         \Drupal\Core\Entity\Query\QueryInterface::accessCheck() with TRUE or FALSE to specify whether access should be checked.                  
         💡 See https://www.drupal.org/node/3201242                                                                                               
 ------ ----------------------------------------------------------------------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------------------------------------------------------------------- 
  Line   modules/farm_rothamsted_experiment/src/Form/ExperimentVariableForm.php                                                                   
 ------ ----------------------------------------------------------------------------------------------------------------------------------------- 
  455    \Drupal calls should be avoided in classes, use dependency injection instead                                                             
  460    \Drupal calls should be avoided in classes, use dependency injection instead                                                             
  611    Relying on entity queries to check access by default is deprecated in drupal:9.2.0 and an error will be thrown from drupal:10.0.0. Call  
         \Drupal\Core\Entity\Query\QueryInterface::accessCheck() with TRUE or FALSE to specify whether access should be checked.                  
         💡 See https://www.drupal.org/node/3201242                                                                                               
 ------ ----------------------------------------------------------------------------------------------------------------------------------------- 

 ------ -------------------------------------------------------------------------------------------------------------------------- 
  Line   modules/farm_rothamsted_experiment/src/Menu/RothamstedTaskProvider.php                                                    
 ------ -------------------------------------------------------------------------------------------------------------------------- 
  27     Constructor of class Drupal\farm_rothamsted_experiment\Menu\RothamstedTaskProvider has an unused parameter $entity_type.  
 ------ -------------------------------------------------------------------------------------------------------------------------- 

 ------ -------------------------------------------------------------------------------------------- 
  Line   modules/farm_rothamsted_experiment/src/Plugin/views/join/RothamstedExperimentAssetLogs.php  
 ------ -------------------------------------------------------------------------------------------- 
  31     \Drupal calls should be avoided in classes, use dependency injection instead                
 ------ -------------------------------------------------------------------------------------------- 

 ------ --------------------------------------------------------------------------------------- 
  Line   modules/farm_rothamsted_experiment/src/Plugin/views/join/RothamstedExperimentLogs.php  
 ------ --------------------------------------------------------------------------------------- 
  31     \Drupal calls should be avoided in classes, use dependency injection instead           
 ------ --------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------- 
  Line   modules/farm_rothamsted_experiment/src/Plugin/views/join/RothamstedExperimentPlotLogs.php  
 ------ ------------------------------------------------------------------------------------------- 
  31     \Drupal calls should be avoided in classes, use dependency injection instead               
 ------ ------------------------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------------------------------------------------------------------- 
  Line   modules/farm_rothamsted_experiment_research/farm_rothamsted_experiment_research.module                                                   
 ------ ----------------------------------------------------------------------------------------------------------------------------------------- 
  404    Relying on entity queries to check access by default is deprecated in drupal:9.2.0 and an error will be thrown from drupal:10.0.0. Call  
         \Drupal\Core\Entity\Query\QueryInterface::accessCheck() with TRUE or FALSE to specify whether access should be checked.                  
         💡 See https://www.drupal.org/node/3201242                                                                                               
 ------ ----------------------------------------------------------------------------------------------------------------------------------------- 

 ------ -------------------------------------------------------------------------------- 
  Line   modules/farm_rothamsted_notification/farm_rothamsted_notification.module        
 ------ -------------------------------------------------------------------------------- 
  120    Variable $changed_fields on left side of ?? always exists and is not nullable.  
 ------ -------------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------------------------------------------------------------------- 
  Line   modules/farm_rothamsted_quick/farm_rothamsted_quick.post_update.php                                                                      
 ------ ----------------------------------------------------------------------------------------------------------------------------------------- 
  54     Relying on entity queries to check access by default is deprecated in drupal:9.2.0 and an error will be thrown from drupal:10.0.0. Call  
         \Drupal\Core\Entity\Query\QueryInterface::accessCheck() with TRUE or FALSE to specify whether access should be checked.                  
         💡 See https://www.drupal.org/node/3201242                                                                                               
  107    Relying on entity queries to check access by default is deprecated in drupal:9.2.0 and an error will be thrown from drupal:10.0.0. Call  
         \Drupal\Core\Entity\Query\QueryInterface::accessCheck() with TRUE or FALSE to specify whether access should be checked.                  
         💡 See https://www.drupal.org/node/3201242                                                                                               
 ------ ----------------------------------------------------------------------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------------------------------------------------------------------- 
  Line   modules/farm_rothamsted_quick/src/Plugin/QuickForm/QuickExperimentFormBase.php                                                           
 ------ ----------------------------------------------------------------------------------------------------------------------------------------- 
  168    \Drupal calls should be avoided in classes, use dependency injection instead                                                             
  339    Relying on entity queries to check access by default is deprecated in drupal:9.2.0 and an error will be thrown from drupal:10.0.0. Call  
         \Drupal\Core\Entity\Query\QueryInterface::accessCheck() with TRUE or FALSE to specify whether access should be checked.                  
         💡 See https://www.drupal.org/node/3201242                                                                                               
  343    \Drupal calls should be avoided in classes, use dependency injection instead                                                             
  353    Relying on entity queries to check access by default is deprecated in drupal:9.2.0 and an error will be thrown from drupal:10.0.0. Call  
         \Drupal\Core\Entity\Query\QueryInterface::accessCheck() with TRUE or FALSE to specify whether access should be checked.                  
         💡 See https://www.drupal.org/node/3201242                                                                                               
  858    \Drupal calls should be avoided in classes, use dependency injection instead                                                             
  862    \Drupal calls should be avoided in classes, use dependency injection instead                                                             
  863    Call to deprecated method getId() of class Drupal\farm_quick\Plugin\QuickForm\QuickFormBase:                                             
         in farm:2.2.0 and is removed from farm:3.0.0.                                                                                            
         Use QuickFormInterface::getQuickId() instead.                                                                                            
  875    \Drupal calls should be avoided in classes, use dependency injection instead                                                             
  890    \Drupal calls should be avoided in classes, use dependency injection instead                                                             
  917    \Drupal calls should be avoided in classes, use dependency injection instead                                                             
  928    \Drupal calls should be avoided in classes, use dependency injection instead                                                             
  929    Call to deprecated method getId() of class Drupal\farm_quick\Plugin\QuickForm\QuickFormBase:                                             
         in farm:2.2.0 and is removed from farm:3.0.0.                                                                                            
         Use QuickFormInterface::getQuickId() instead.                                                                                            
  932    \Drupal calls should be avoided in classes, use dependency injection instead                                                             
  969    Variable $asset_type in empty() is never defined.                                                                                        
 ------ ----------------------------------------------------------------------------------------------------------------------------------------- 

                                                                                                                        
 [ERROR] Found 30 errors                                                                                                
                                                                                                                        

```