### PR TITLE
Link geometry and variable upload files to revision history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Manual form for migrating plan files. [#645](https://github.com/Rothamsted-Ecoinformatics/farm_rothamsted/issues/645)
+
+### Fixed
+
+- Fix and standarize plan revision creation across all plan forms. [#645](https://github.com/Rothamsted-Ecoinformatics/farm_rothamsted/issues/645)
+
 ## [2.29.0](https://github.com/Rothamsted-Ecoinformatics/farm_rothamsted/milestone/53)
 
 ### Added

--- a/modules/farm_rothamsted_experiment/farm_rothamsted_experiment.module
+++ b/modules/farm_rothamsted_experiment/farm_rothamsted_experiment.module
@@ -293,6 +293,10 @@ function farm_rothamsted_experiment_farm_ui_theme_field_group_items(string $enti
     return [
       'location' => 'locations',
       'asset' => 'locations',
+      'columns_file' => 'file',
+      'column_levels_file' => 'file',
+      'plot_attributes_file' => 'file',
+      'plot_geometry_file' => 'file',
       'experiment_plan_link' => 'file',
       'experiment_file_link' => 'file',
       'other_links' => 'file',

--- a/modules/farm_rothamsted_experiment/farm_rothamsted_experiment.post_update.php
+++ b/modules/farm_rothamsted_experiment/farm_rothamsted_experiment.post_update.php
@@ -1032,3 +1032,45 @@ function farm_rothamsted_experiment_post_update_2_26_plan_status_change_actions(
     \Drupal::configFactory()->getEditable("system.action.$action_id")->setData($data)->save(TRUE);
   }
 }
+
+function farm_rothamsted_experiment_post_update_2_30_add_file_fields(&$sandbox = NULL) {
+
+  $fields['columns_file'] = BundleFieldDefinition::create('file')
+    ->setRevisionable(TRUE)
+    ->setCardinality(1)
+    ->setSettings([
+      'description_field' => FALSE,
+      'file_extensions' => 'csv',
+    ]);
+  $fields['column_levels_file'] = BundleFieldDefinition::create('file')
+    ->setRevisionable(TRUE)
+    ->setCardinality(1)
+    ->setSettings([
+      'description_field' => FALSE,
+      'file_extensions' => 'csv',
+    ]);
+  $fields['plot_attributes_file'] = BundleFieldDefinition::create('file')
+    ->setRevisionable(TRUE)
+    ->setCardinality(1)
+    ->setSettings([
+      'description_field' => FALSE,
+      'file_extensions' => 'csv',
+    ]);
+  $fields['plot_geometry_file'] = BundleFieldDefinition::create('file')
+    ->setRevisionable(TRUE)
+    ->setCardinality(1)
+    ->setSettings([
+      'description_field' => FALSE,
+      'file_extensions' => 'geojson',
+    ]);
+
+  // Install each field definition.
+  foreach ($fields as $field_name => $field_definition) {
+    \Drupal::entityDefinitionUpdateManager()->installFieldStorageDefinition(
+      $field_name,
+      'plan',
+      'farm_rothamsted_experiment',
+      $field_definition,
+    );
+  }
+}

--- a/modules/farm_rothamsted_experiment/farm_rothamsted_experiment.post_update.php
+++ b/modules/farm_rothamsted_experiment/farm_rothamsted_experiment.post_update.php
@@ -1033,6 +1033,9 @@ function farm_rothamsted_experiment_post_update_2_26_plan_status_change_actions(
   }
 }
 
+/**
+ * Add dedicated file fields for plan metadata.
+ */
 function farm_rothamsted_experiment_post_update_2_30_add_file_fields(&$sandbox = NULL) {
 
   $fields['columns_file'] = BundleFieldDefinition::create('file')

--- a/modules/farm_rothamsted_experiment/farm_rothamsted_experiment.routing.yml
+++ b/modules/farm_rothamsted_experiment/farm_rothamsted_experiment.routing.yml
@@ -64,3 +64,23 @@ farm_rothamsted_experiment.experiment.variable_form:
         type: entity:plan
         bundle:
           - rothamsted_experiment
+farm_rothamsted_experiment.plan_file_migration_list:
+  path: '/plan/file-migration'
+  defaults:
+    _controller: \Drupal\farm_rothamsted_experiment\Controller\PlanFileMigrationController::listPlans
+    _title: 'Plan File Migration'
+  requirements:
+    _role: 'rothamsted_data_admin'
+farm_rothamsted_experiment.plan_file_migration_form:
+  path: '/plan/{plan}/migrate-files'
+  defaults:
+    _form: \Drupal\farm_rothamsted_experiment\Form\PlanFileMigrationForm
+    _title: 'Migrate Plan Files'
+  requirements:
+    _custom_access: \Drupal\farm_rothamsted_experiment\Form\PlanFileMigrationForm::access
+  options:
+    parameters:
+      plan:
+        type: entity:plan
+        bundle:
+          - rothamsted_experiment

--- a/modules/farm_rothamsted_experiment/src/Controller/PlanFileMigrationController.php
+++ b/modules/farm_rothamsted_experiment/src/Controller/PlanFileMigrationController.php
@@ -6,6 +6,8 @@ use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Link;
 use Drupal\Core\Url;
 
+// phpcs:disable DrupalPractice.Objects.GlobalDrupal.GlobalDrupal
+
 /**
  * Controller for listing plans that need file migration.
  */
@@ -14,7 +16,7 @@ class PlanFileMigrationController extends ControllerBase {
   /**
    * List plans that need file migration.
    *
-   * Shows plans with column_descriptors populated but missing the 4 new file fields.
+   * Shows plans with column_descriptors but missing data in new file fields.
    *
    * @return array
    *   Render array.

--- a/modules/farm_rothamsted_experiment/src/Controller/PlanFileMigrationController.php
+++ b/modules/farm_rothamsted_experiment/src/Controller/PlanFileMigrationController.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Drupal\farm_rothamsted_experiment\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Link;
+use Drupal\Core\Url;
+
+/**
+ * Controller for listing plans that need file migration.
+ */
+class PlanFileMigrationController extends ControllerBase {
+
+  /**
+   * List plans that need file migration.
+   *
+   * Shows plans with column_descriptors populated but missing the 4 new file fields.
+   *
+   * @return array
+   *   Render array.
+   */
+  public function listPlans() {
+    $plan_storage = $this->entityTypeManager()->getStorage('plan');
+
+    // Query plans with column_descriptors populated.
+    $query = $plan_storage->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('type', 'rothamsted_experiment')
+      ->exists('column_descriptors')
+      ->sort('id', 'ASC');
+
+    // Filter to plans that don't have the 4 new file fields populated.
+    $query->notExists('columns_file');
+    $query->notExists('column_levels_file');
+    $query->notExists('plot_attributes_file');
+    $query->notExists('plot_geometry_file');
+
+    $plan_ids = $query->execute();
+
+    if (empty($plan_ids)) {
+      return [
+        '#markup' => $this->t('No plans require file migration.'),
+      ];
+    }
+
+    $plans = $plan_storage->loadMultiple($plan_ids);
+
+    $rows = [];
+    foreach ($plans as $plan) {
+      $migrate_url = Url::fromRoute('farm_rothamsted_experiment.plan_file_migration_form', ['plan' => $plan->id()]);
+
+      // Get the last updated timestamp.
+      $last_updated = \Drupal::service('date.formatter')->format($plan->getChangedTime(), 'short');
+
+      $rows[] = [
+        $plan->id(),
+        $plan->label(),
+        $last_updated,
+        Link::fromTextAndUrl($this->t('Migrate files'), $migrate_url),
+      ];
+    }
+
+    $build = [
+      '#type' => 'table',
+      '#header' => [
+        $this->t('Plan ID'),
+        $this->t('Plan Name'),
+        $this->t('Last Updated'),
+        $this->t('Actions'),
+      ],
+      '#rows' => $rows,
+      '#empty' => $this->t('No plans require file migration.'),
+    ];
+
+    return $build;
+  }
+
+}

--- a/modules/farm_rothamsted_experiment/src/Form/ExperimentPlotForm.php
+++ b/modules/farm_rothamsted_experiment/src/Form/ExperimentPlotForm.php
@@ -195,8 +195,12 @@ class ExperimentPlotForm extends ExperimentFormBase {
       // Append all IDs to the plan.
       $plan = Plan::load($plan_id);
       $plan->set('plot', $context['results']);
-      $plan->setRevisionLogMessage($revision_message);
+
+      // Save the plan with a new revision.
       $plan->setNewRevision(TRUE);
+      $plan->setRevisionLogMessage($revision_message);
+      $plan->setRevisionCreationTime(\Drupal::time()->getRequestTime());
+      $plan->setRevisionUserId(\Drupal::currentUser()->id());
       $plan->save();
 
       // Add success message.

--- a/modules/farm_rothamsted_experiment/src/Form/ExperimentPlotGeometryForm.php
+++ b/modules/farm_rothamsted_experiment/src/Form/ExperimentPlotGeometryForm.php
@@ -2,46 +2,28 @@
 
 namespace Drupal\farm_rothamsted_experiment\Form;
 
+use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Component\Serialization\Json;
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Access\AccessResultForbidden;
+use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\plan\Entity\Plan;
 use Drupal\plan\Entity\PlanInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Experiment plot geometry form.
  */
 class ExperimentPlotGeometryForm extends ExperimentFormBase {
 
-  /**
-   * The entity type manager service.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
+  use AutowireTrait;
 
-  /**
-   * Constructs new form.
-   *
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager service.
-   */
-  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
-    $this->entityTypeManager = $entity_type_manager;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('entity_type.manager'),
-    );
-  }
+  public function __construct(
+    protected EntityTypeManagerInterface $entityTypeManager,
+    protected TimeInterface $time,
+  ) {}
 
   /**
    * {@inheritdoc}
@@ -269,6 +251,12 @@ class ExperimentPlotGeometryForm extends ExperimentFormBase {
     if ($file_ids = $form_state->getValue('geojson')) {
       $file = $this->entityTypeManager->getStorage('file')->load(reset($file_ids));
       $plan->set('plot_geometry_file', $file);
+
+      // Save the plan with a new revision.
+      $plan->setNewRevision(TRUE);
+      $plan->setRevisionLogMessage($revision_message);
+      $plan->setRevisionCreationTime($this->time->getRequestTime());
+      $plan->setRevisionUserId($this->currentUser()->id());
       $plan->save();
     }
 

--- a/modules/farm_rothamsted_experiment/src/Form/ExperimentPlotGeometryForm.php
+++ b/modules/farm_rothamsted_experiment/src/Form/ExperimentPlotGeometryForm.php
@@ -104,7 +104,7 @@ class ExperimentPlotGeometryForm extends ExperimentFormBase {
     }
 
     // Allow uploading a geojson.
-    $plan_file_location = $this->getFileUploadLocation('plan', 'rothamsted_experiment', 'file');
+    $plan_file_location = $this->getFileUploadLocation('plan', 'rothamsted_experiment', 'plot_geometry_file');
     $form['geojson'] = [
       '#type' => 'managed_file',
       '#title' => $this->t('Plot geometries'),
@@ -268,7 +268,7 @@ class ExperimentPlotGeometryForm extends ExperimentFormBase {
     // Add the geojson file to the plan.
     if ($file_ids = $form_state->getValue('geojson')) {
       $file = $this->entityTypeManager->getStorage('file')->load(reset($file_ids));
-      $plan->get('file')->appendItem($file);
+      $plan->set('plot_geometry_file', $file);
       $plan->save();
     }
 

--- a/modules/farm_rothamsted_experiment/src/Form/ExperimentVariableForm.php
+++ b/modules/farm_rothamsted_experiment/src/Form/ExperimentVariableForm.php
@@ -90,7 +90,7 @@ class ExperimentVariableForm extends ExperimentFormBase {
 
     // Add file upload fields.
     // Require all 3 CSV files to be uploaded.
-    $plan_file_location = $this->getFileUploadLocation('plan', 'rothamsted_experiment', 'file');
+    $plan_file_location = $this->getFileUploadLocation('plan', 'rothamsted_experiment', 'columns_file');
     $form['column_descriptors'] = [
       '#type' => 'managed_file',
       '#title' => $this->t('Column descriptors'),
@@ -578,13 +578,13 @@ class ExperimentVariableForm extends ExperimentFormBase {
 
     // Save uploaded files.
     $files = [
-      'column_descriptors',
-      'column_levels',
-      'plot_attributes',
+      'column_descriptors' => 'columns_file',
+      'column_levels' => 'column_levels_file',
+      'plot_attributes' => 'plot_attributes_file',
     ];
-    foreach ($files as $form_key) {
+    foreach ($files as $form_key => $file_field) {
       if ($file_ids = $form_state->getValue($form_key)) {
-        $plan->get('file')->appendItem(reset($file_ids));
+        $plan->set($file_field, reset($file_ids));
       }
     }
 

--- a/modules/farm_rothamsted_experiment/src/Form/ExperimentVariableForm.php
+++ b/modules/farm_rothamsted_experiment/src/Form/ExperimentVariableForm.php
@@ -2,44 +2,26 @@
 
 namespace Drupal\farm_rothamsted_experiment\Form;
 
+use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Access\AccessResult;
+use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\plan\Entity\Plan;
 use Drupal\plan\Entity\PlanInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Form for uploading experiment variables.
  */
 class ExperimentVariableForm extends ExperimentFormBase {
 
-  /**
-   * The entity type manager service.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
+  use AutowireTrait;
 
-  /**
-   * Constructs new form.
-   *
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager service.
-   */
-  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
-    $this->entityTypeManager = $entity_type_manager;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('entity_type.manager'),
-    );
-  }
+  public function __construct(
+    protected EntityTypeManagerInterface $entityTypeManager,
+    protected TimeInterface $time,
+  ) {}
 
   /**
    * {@inheritdoc}
@@ -588,9 +570,10 @@ class ExperimentVariableForm extends ExperimentFormBase {
       }
     }
 
-    // Finally, save the plan.
+    // Finally, save the plan, with a new revision.
     $plan->setNewRevision(TRUE);
     $plan->setRevisionLogMessage($revision_message);
+    $plan->setRevisionCreationTime($this->time->getRequestTime());
     $plan->setRevisionUserId($this->currentUser()->id());
     $plan->save();
 

--- a/modules/farm_rothamsted_experiment/src/Form/ExperimentVariableForm.php
+++ b/modules/farm_rothamsted_experiment/src/Form/ExperimentVariableForm.php
@@ -591,6 +591,7 @@ class ExperimentVariableForm extends ExperimentFormBase {
     // Finally, save the plan.
     $plan->setNewRevision(TRUE);
     $plan->setRevisionLogMessage($revision_message);
+    $plan->setRevisionUserId($this->currentUser()->id());
     $plan->save();
 
     // Redirect to the plan variables page after processing.

--- a/modules/farm_rothamsted_experiment/src/Form/PlanFileMigrationForm.php
+++ b/modules/farm_rothamsted_experiment/src/Form/PlanFileMigrationForm.php
@@ -2,14 +2,15 @@
 
 namespace Drupal\farm_rothamsted_experiment\Form;
 
+use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Access\AccessResult;
+use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Url;
 use Drupal\plan\Entity\PlanInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 // phpcs:disable DrupalPractice.Objects.GlobalDrupal.GlobalDrupal
 
@@ -18,31 +19,12 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class PlanFileMigrationForm extends FormBase {
 
-  /**
-   * The entity type manager service.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
+  use AutowireTrait;
 
-  /**
-   * Constructs a new PlanFileMigrationForm.
-   *
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager service.
-   */
-  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
-    $this->entityTypeManager = $entity_type_manager;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('entity_type.manager')
-    );
-  }
+  public function __construct(
+    protected EntityTypeManagerInterface $entityTypeManager,
+    protected TimeInterface $time,
+  ) {}
 
   /**
    * {@inheritdoc}
@@ -299,6 +281,7 @@ class PlanFileMigrationForm extends FormBase {
     // Save the plan with a new revision.
     $plan->setNewRevision(TRUE);
     $plan->setRevisionLogMessage($revision_message);
+    $plan->setRevisionCreationTime($this->time->getRequestTime());
     $plan->setRevisionUserId($this->currentUser()->id());
     $plan->save();
 

--- a/modules/farm_rothamsted_experiment/src/Form/PlanFileMigrationForm.php
+++ b/modules/farm_rothamsted_experiment/src/Form/PlanFileMigrationForm.php
@@ -1,0 +1,312 @@
+<?php
+
+namespace Drupal\farm_rothamsted_experiment\Form;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Url;
+use Drupal\plan\Entity\PlanInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Form for manually migrating plan files to dedicated fields.
+ */
+class PlanFileMigrationForm extends FormBase {
+
+  /**
+   * The entity type manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Constructs a new PlanFileMigrationForm.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager service.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity_type.manager')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'plan_file_migration_form';
+  }
+
+  /**
+   * Access check.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   Run access checks for this account.
+   * @param \Drupal\plan\Entity\PlanInterface $plan
+   *   The plan entity.
+   *
+   * @return \Drupal\Core\Access\AccessResultInterface
+   *   The access result.
+   */
+  public function access(AccountInterface $account, PlanInterface $plan) {
+    return $plan->access('update', $account, TRUE)
+      ->andIf(AccessResult::allowedIfHasPermission($account, 'administer rothamsted_experiment plan'));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state, ?PlanInterface $plan = NULL) {
+
+    // Bail if no plan.
+    if (empty($plan)) {
+      return $form;
+    }
+
+    // Save the plan ID.
+    $form['plan_id'] = [
+      '#type' => 'hidden',
+      '#value' => $plan->id(),
+    ];
+
+    $plan_link = \Drupal::service('link_generator')->generate($plan->label(), $plan->toUrl());
+    $migration_list_link = \Drupal::service('link_generator')->generate($this->t('Back to migration list'), Url::fromRoute('farm_rothamsted_experiment.plan_file_migration_list'));
+    $form['plan_info'] = [
+      '#type' => 'item',
+      '#markup' => $this->t('<p>@back</p><h2>Migrate files for Plan #@id: @link</h2>', [
+        '@back' => $migration_list_link,
+        '@id' => $plan->id(),
+        '@link' => $plan_link,
+      ]),
+    ];
+
+    // Get all files attached to the plan.
+    $files = $plan->get('file')->referencedEntities();
+
+    // Sort files by creation time, newest first.
+    usort($files, function ($a, $b) {
+      return $b->getCreatedTime() - $a->getCreatedTime();
+    });
+
+    if (empty($files)) {
+      $form['no_files'] = [
+        '#type' => 'item',
+        '#markup' => $this->t('This plan has no files attached.'),
+      ];
+      return $form;
+    }
+
+    // Build file table.
+    $form['files'] = [
+      '#type' => 'table',
+      '#header' => [
+        $this->t('Filename'),
+        $this->t('Created'),
+        $this->t('User'),
+        $this->t('Download'),
+        $this->t('Action'),
+      ],
+      '#empty' => $this->t('No files found.'),
+    ];
+
+    $user_storage = $this->entityTypeManager->getStorage('user');
+
+    foreach ($files as $file) {
+      $file_id = $file->id();
+
+      // Get file metadata.
+      $created = \Drupal::service('date.formatter')->format($file->getCreatedTime(), 'short');
+
+      // Get the user who uploaded the file.
+      $uid = $file->getOwnerId();
+      $user = $user_storage->load($uid);
+      $username = $user ? $user->getDisplayName() : $this->t('Unknown');
+
+      // Build download link.
+      $download_url = Url::fromUri(\Drupal::service('file_url_generator')->generateAbsoluteString($file->getFileUri()));
+      $download_link = \Drupal::service('link_generator')->generate($this->t('Download'), $download_url);
+
+      $form['files'][$file_id]['filename'] = [
+        '#plain_text' => $file->getFilename(),
+      ];
+
+      $form['files'][$file_id]['created'] = [
+        '#plain_text' => $created,
+      ];
+
+      $form['files'][$file_id]['user'] = [
+        '#plain_text' => $username,
+      ];
+
+      $form['files'][$file_id]['download'] = [
+        '#markup' => $download_link,
+      ];
+
+      $form['files'][$file_id]['action'] = [
+        '#type' => 'select',
+        '#options' => [
+          '' => $this->t('- No action -'),
+          'archive' => $this->t('Archive (remove from file field)'),
+          'columns_file' => $this->t('Move to Columns file'),
+          'column_levels_file' => $this->t('Move to Column Levels file'),
+          'plot_attributes_file' => $this->t('Move to Plot Attributes file'),
+          'plot_geometry_file' => $this->t('Move to Plot Geometry file'),
+        ],
+        '#default_value' => '',
+      ];
+    }
+
+    $form['revision_message'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Revision message'),
+      '#description' => $this->t('Describe the changes made during this migration.'),
+      '#required' => TRUE,
+    ];
+
+    $form['actions'] = [
+      '#type' => 'actions',
+    ];
+
+    $form['actions']['submit'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Migrate files'),
+    ];
+
+    $form['actions']['cancel'] = [
+      '#type' => 'link',
+      '#title' => $this->t('Cancel'),
+      '#url' => Url::fromRoute('farm_rothamsted_experiment.plan_file_migration_list'),
+      '#attributes' => ['class' => ['button']],
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state) {
+    $files = $form_state->getValue('files');
+
+    if (empty($files)) {
+      return;
+    }
+
+    // Track which destination fields have been assigned.
+    $destination_fields = [
+      'columns_file' => NULL,
+      'column_levels_file' => NULL,
+      'plot_attributes_file' => NULL,
+      'plot_geometry_file' => NULL,
+    ];
+
+    foreach ($files as $file_id => $file_data) {
+      $action = $file_data['action'];
+
+      // Skip if no action or archive.
+      if (empty($action) || $action === 'archive') {
+        continue;
+      }
+
+      // Check if this destination field is already assigned.
+      if ($destination_fields[$action] !== NULL) {
+        $form_state->setErrorByName("files][$file_id][action", $this->t('Multiple files cannot be assigned to the same destination field. Another file is already assigned to @field.', [
+          '@field' => $action,
+        ]));
+      }
+      else {
+        // Mark this destination field as assigned.
+        $destination_fields[$action] = $file_id;
+      }
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $plan_id = $form_state->getValue('plan_id');
+    $plan = $this->entityTypeManager->getStorage('plan')->load($plan_id);
+
+    if (!$plan) {
+      $this->messenger()->addError($this->t('Plan not found.'));
+      return;
+    }
+
+    $files = $form_state->getValue('files');
+    $revision_message = $form_state->getValue('revision_message');
+
+    // Track files to keep in the file field.
+    $files_to_keep = [];
+
+    // Track files to move to dedicated fields.
+    $destination_files = [
+      'columns_file' => NULL,
+      'column_levels_file' => NULL,
+      'plot_attributes_file' => NULL,
+      'plot_geometry_file' => NULL,
+    ];
+
+    // Get current file references.
+    $current_files = [];
+    foreach ($plan->get('file')->referencedEntities() as $file) {
+      $current_files[$file->id()] = $file->id();
+    }
+
+    // Process each file action.
+    foreach ($files as $file_id => $file_data) {
+      $action = $file_data['action'];
+
+      if (empty($action)) {
+        // No action - keep in file field.
+        $files_to_keep[] = $file_id;
+      }
+      elseif ($action === 'archive') {
+        // Archive - don't add to files_to_keep.
+        continue;
+      }
+      elseif (!isset($destination_files[$action])) {
+        // Move to dedicated field.
+        $destination_files[$action] = $file_id;
+      }
+    }
+
+    // Update the plan.
+    // Clear the file field and re-add files to keep.
+    $plan->set('file', $files_to_keep);
+
+    // Set the dedicated file fields.
+    foreach ($destination_files as $field_name => $file_id) {
+      if ($file_id !== NULL) {
+        $plan->set($field_name, $file_id);
+      }
+    }
+
+    // Save the plan with a new revision.
+    $plan->setNewRevision(TRUE);
+    $plan->setRevisionLogMessage($revision_message);
+    $plan->setRevisionUserId($this->currentUser()->id());
+    $plan->save();
+
+    $plan_link = $plan->toLink($plan->label())->toString();
+    $this->messenger()->addStatus($this->t('Files have been migrated successfully for @plan.', [
+      '@plan' => $plan_link,
+    ]));
+
+    // Redirect to the migration list.
+    $form_state->setRedirect('farm_rothamsted_experiment.plan_file_migration_list');
+  }
+
+}

--- a/modules/farm_rothamsted_experiment/src/Form/PlanFileMigrationForm.php
+++ b/modules/farm_rothamsted_experiment/src/Form/PlanFileMigrationForm.php
@@ -11,6 +11,8 @@ use Drupal\Core\Url;
 use Drupal\plan\Entity\PlanInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
+// phpcs:disable DrupalPractice.Objects.GlobalDrupal.GlobalDrupal
+
 /**
  * Form for manually migrating plan files to dedicated fields.
  */

--- a/modules/farm_rothamsted_experiment/src/Plugin/Plan/PlanType/Experiment.php
+++ b/modules/farm_rothamsted_experiment/src/Plugin/Plan/PlanType/Experiment.php
@@ -162,6 +162,10 @@ class Experiment extends FarmPlanType {
       'description_field' => TRUE,
       'file_extensions' => 'csv doc docx gz geojson gpx kml kmz logz mp3 odp ods odt ogg pdf ppt pptx tar tif tiff txt wav xls xlsx zip',
     ];
+    $simple_file_view_display_options = [
+      'type' => 'file_uri_plain',
+      'label' => 'inline',
+    ];
     $fields['columns_file'] = BundleFieldDefinition::create('file')
       ->setLabel($this->t('Columns'))
       ->setRevisionable(TRUE)
@@ -174,7 +178,8 @@ class Experiment extends FarmPlanType {
       ->setDisplayOptions('form', [
         'region' => 'hidden',
       ])
-      ->setDisplayConfigurable('view', TRUE);
+      ->setDisplayConfigurable('view', TRUE)
+      ->setDisplayOptions('view', $simple_file_view_display_options);
      $fields['column_levels_file'] = BundleFieldDefinition::create('file')
       ->setLabel($this->t('Column levels'))
       ->setRevisionable(TRUE)
@@ -187,7 +192,8 @@ class Experiment extends FarmPlanType {
       ->setDisplayOptions('form', [
         'region' => 'hidden',
       ])
-      ->setDisplayConfigurable('view', TRUE);
+      ->setDisplayConfigurable('view', TRUE)
+      ->setDisplayOptions('view', $simple_file_view_display_options);
      $fields['plot_attributes_file'] = BundleFieldDefinition::create('file')
       ->setLabel($this->t('Plot attributes'))
       ->setRevisionable(TRUE)
@@ -200,7 +206,8 @@ class Experiment extends FarmPlanType {
       ->setDisplayOptions('form', [
         'region' => 'hidden',
       ])
-      ->setDisplayConfigurable('view', TRUE);
+      ->setDisplayConfigurable('view', TRUE)
+       ->setDisplayOptions('view', $simple_file_view_display_options);
      $fields['plot_geometry_file'] = BundleFieldDefinition::create('file')
       ->setLabel($this->t('Plot geometries'))
       ->setRevisionable(TRUE)
@@ -213,7 +220,8 @@ class Experiment extends FarmPlanType {
       ->setDisplayOptions('form', [
         'region' => 'hidden',
       ])
-      ->setDisplayConfigurable('view', TRUE);
+      ->setDisplayConfigurable('view', TRUE)
+      ->setDisplayOptions('view', $simple_file_view_display_options);
 
     $fields['agreed_quote'] = BundleFieldDefinition::create('file')
       ->setLabel($this->t('Agreed Quote'))

--- a/modules/farm_rothamsted_experiment/src/Plugin/Plan/PlanType/Experiment.php
+++ b/modules/farm_rothamsted_experiment/src/Plugin/Plan/PlanType/Experiment.php
@@ -170,7 +170,7 @@ class Experiment extends FarmPlanType {
       ->setLabel($this->t('Columns'))
       ->setRevisionable(TRUE)
       ->setCardinality(1)
-      ->setSettings([
+      ->setSettings($file_settings + [
         'description_field' => FALSE,
         'file_extensions' => 'csv',
       ])
@@ -184,7 +184,7 @@ class Experiment extends FarmPlanType {
       ->setLabel($this->t('Column levels'))
       ->setRevisionable(TRUE)
       ->setCardinality(1)
-      ->setSettings([
+      ->setSettings($file_settings + [
         'description_field' => FALSE,
         'file_extensions' => 'csv',
       ])
@@ -198,7 +198,7 @@ class Experiment extends FarmPlanType {
       ->setLabel($this->t('Plot attributes'))
       ->setRevisionable(TRUE)
       ->setCardinality(1)
-      ->setSettings([
+      ->setSettings($file_settings + [
         'description_field' => FALSE,
         'file_extensions' => 'csv',
       ])
@@ -212,7 +212,7 @@ class Experiment extends FarmPlanType {
       ->setLabel($this->t('Plot geometries'))
       ->setRevisionable(TRUE)
       ->setCardinality(1)
-      ->setSettings([
+      ->setSettings($file_settings + [
         'description_field' => FALSE,
         'file_extensions' => 'geojson',
       ])

--- a/modules/farm_rothamsted_experiment/src/Plugin/Plan/PlanType/Experiment.php
+++ b/modules/farm_rothamsted_experiment/src/Plugin/Plan/PlanType/Experiment.php
@@ -180,7 +180,7 @@ class Experiment extends FarmPlanType {
       ])
       ->setDisplayConfigurable('view', TRUE)
       ->setDisplayOptions('view', $simple_file_view_display_options);
-     $fields['column_levels_file'] = BundleFieldDefinition::create('file')
+    $fields['column_levels_file'] = BundleFieldDefinition::create('file')
       ->setLabel($this->t('Column levels'))
       ->setRevisionable(TRUE)
       ->setCardinality(1)
@@ -194,7 +194,7 @@ class Experiment extends FarmPlanType {
       ])
       ->setDisplayConfigurable('view', TRUE)
       ->setDisplayOptions('view', $simple_file_view_display_options);
-     $fields['plot_attributes_file'] = BundleFieldDefinition::create('file')
+    $fields['plot_attributes_file'] = BundleFieldDefinition::create('file')
       ->setLabel($this->t('Plot attributes'))
       ->setRevisionable(TRUE)
       ->setCardinality(1)
@@ -207,8 +207,8 @@ class Experiment extends FarmPlanType {
         'region' => 'hidden',
       ])
       ->setDisplayConfigurable('view', TRUE)
-       ->setDisplayOptions('view', $simple_file_view_display_options);
-     $fields['plot_geometry_file'] = BundleFieldDefinition::create('file')
+      ->setDisplayOptions('view', $simple_file_view_display_options);
+    $fields['plot_geometry_file'] = BundleFieldDefinition::create('file')
       ->setLabel($this->t('Plot geometries'))
       ->setRevisionable(TRUE)
       ->setCardinality(1)

--- a/modules/farm_rothamsted_experiment/src/Plugin/Plan/PlanType/Experiment.php
+++ b/modules/farm_rothamsted_experiment/src/Plugin/Plan/PlanType/Experiment.php
@@ -162,6 +162,59 @@ class Experiment extends FarmPlanType {
       'description_field' => TRUE,
       'file_extensions' => 'csv doc docx gz geojson gpx kml kmz logz mp3 odp ods odt ogg pdf ppt pptx tar tif tiff txt wav xls xlsx zip',
     ];
+    $fields['columns_file'] = BundleFieldDefinition::create('file')
+      ->setLabel($this->t('Columns'))
+      ->setRevisionable(TRUE)
+      ->setCardinality(1)
+      ->setSettings([
+        'description_field' => FALSE,
+        'file_extensions' => 'csv',
+      ])
+      ->setDisplayConfigurable('form', TRUE)
+      ->setDisplayOptions('form', [
+        'region' => 'hidden',
+      ])
+      ->setDisplayConfigurable('view', TRUE);
+     $fields['column_levels_file'] = BundleFieldDefinition::create('file')
+      ->setLabel($this->t('Column levels'))
+      ->setRevisionable(TRUE)
+      ->setCardinality(1)
+      ->setSettings([
+        'description_field' => FALSE,
+        'file_extensions' => 'csv',
+      ])
+      ->setDisplayConfigurable('form', TRUE)
+      ->setDisplayOptions('form', [
+        'region' => 'hidden',
+      ])
+      ->setDisplayConfigurable('view', TRUE);
+     $fields['plot_attributes_file'] = BundleFieldDefinition::create('file')
+      ->setLabel($this->t('Plot attributes'))
+      ->setRevisionable(TRUE)
+      ->setCardinality(1)
+      ->setSettings([
+        'description_field' => FALSE,
+        'file_extensions' => 'csv',
+      ])
+      ->setDisplayConfigurable('form', TRUE)
+      ->setDisplayOptions('form', [
+        'region' => 'hidden',
+      ])
+      ->setDisplayConfigurable('view', TRUE);
+     $fields['plot_geometry_file'] = BundleFieldDefinition::create('file')
+      ->setLabel($this->t('Plot geometries'))
+      ->setRevisionable(TRUE)
+      ->setCardinality(1)
+      ->setSettings([
+        'description_field' => FALSE,
+        'file_extensions' => 'geojson',
+      ])
+      ->setDisplayConfigurable('form', TRUE)
+      ->setDisplayOptions('form', [
+        'region' => 'hidden',
+      ])
+      ->setDisplayConfigurable('view', TRUE);
+
     $fields['agreed_quote'] = BundleFieldDefinition::create('file')
       ->setLabel($this->t('Agreed Quote'))
       ->setDescription($this->t('The final agreed quotation for the work proposed.'))

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2,6 +2,11 @@ parameters:
 	ignoreErrors:
 		-
 			message: "#^\\\\Drupal calls should be avoided in classes, use dependency injection instead$#"
+			count: 1
+			path: modules/farm_rothamsted_experiment/src/Controller/PlanFileMigrationController.php
+
+		-
+			message: "#^\\\\Drupal calls should be avoided in classes, use dependency injection instead$#"
 			count: 2
 			path: modules/farm_rothamsted_experiment/src/Form/ExperimentPlotGeometryForm.php
 
@@ -9,6 +14,11 @@ parameters:
 			message: "#^\\\\Drupal calls should be avoided in classes, use dependency injection instead$#"
 			count: 2
 			path: modules/farm_rothamsted_experiment/src/Form/ExperimentVariableForm.php
+
+		-
+			message: "#^\\\\Drupal calls should be avoided in classes, use dependency injection instead$#"
+			count: 5
+			path: modules/farm_rothamsted_experiment/src/Form/PlanFileMigrationForm.php
 
 		-
 			message: "#^\\\\Drupal calls should be avoided in classes, use dependency injection instead$#"


### PR DESCRIPTION
This PR is for #645 

Currently this draft PR is only a start at this, it adds the new file fields necessary.

Remaining:

- [ ] Migrate data from existing fields
- [ ] Update plan form(s) to upload new geometry/variable files to the new dedicated file fields