### PR TITLE
Code fixes for Drupal 10.4

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -42,7 +42,7 @@ jobs:
           docker compose exec -u www-data -T www composer update
           docker compose exec -u www-data -T www composer require ${PACKAGE_NAME}:*
       - name: Run PHP CodeSniffer
-        run: docker compose exec -u www-data -T www phpcs /opt/drupal/web/modules/${MODULE_NAME} --exclude=DrupalPractice.InfoFiles.NamespacedDependency
+        run: docker compose exec -u www-data -T www phpcs /opt/drupal/web/modules/${MODULE_NAME} --exclude=DrupalPractice.InfoFiles.NamespacedDependency,SlevomatCodingStandard.TypeHints.DeclareStrictTypes
       - name: Run PHPUnit tests
         run: docker compose exec -u www-data -T www phpunit --verbose --debug /opt/drupal/web/modules/${MODULE_NAME}
       - name: Test installing farmOS and the module

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Update ResearchBreadcrumbBuilder::applies declaration to be compatible with parent method.
+
 ## [2.24.1](https://github.com/Rothamsted-Ecoinformatics/farm_rothamsted/milestone/45)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Update ResearchBreadcrumbBuilder::applies declaration to be compatible with parent method.
+- Update drupal/gin dependency to ^4.0.
 
 ## [2.24.1](https://github.com/Rothamsted-Ecoinformatics/farm_rothamsted/milestone/45)
 

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "farmos/farmos": "^3.3",
     "drupal/autocomplete_deluxe": "^2.0",
     "drupal/farm_rei": "^2.0.0-beta4",
-    "drupal/gin": "^3.0.0-beta5",
+    "drupal/gin": "^4.0",
     "drupal/json_field": "^1.0@RC",
     "drupal/key_value_field": "^1.2"
   }

--- a/modules/farm_rothamsted_experiment_research/src/Breadcrumb/ResearchBreadcrumbBuilder.php
+++ b/modules/farm_rothamsted_experiment_research/src/Breadcrumb/ResearchBreadcrumbBuilder.php
@@ -3,6 +3,7 @@
 namespace Drupal\farm_rothamsted_experiment_research\Breadcrumb;
 
 use Drupal\Core\Breadcrumb\Breadcrumb;
+use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Link;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
@@ -18,7 +19,7 @@ class ResearchBreadcrumbBuilder extends PathBasedBreadcrumbBuilder {
   /**
    * {@inheritdoc}
    */
-  public function applies(RouteMatchInterface $route_match) {
+  public function applies(RouteMatchInterface $route_match, ?CacheableMetadata $cacheable_metadata = NULL) {
 
     // Only apply to experiment plans.
     if ($route_match->getRouteName() == 'entity.plan.canonical') {


### PR DESCRIPTION
A few things we need to fix for Drupal 10.4 included with the FarmOS 3.3.3 release.

At minimum, need to fix:
- Update ResearchBreadcrumbBuilder::applies declaration to be compatible with parent method
This changed with Drupal 10.4 https://www.drupal.org/node/3459274
- Update Gin dependency to ^4

In this PR I'll also investigate adding strict types as well as PHPStan